### PR TITLE
Add dimension table documentation to web page

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,76 @@
                 </div>
             </div>
         </section>
+        <!-- Database Dimensions -->
+        <section class="dimensions-section">
+            <h2>Dimensiones de la Base de Datos</h2>
+
+            <h3>Dimensión de Cuentas</h3>
+            <table class="schema-table">
+                <thead>
+                    <tr><th>Columna</th><th>Descripción</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>cuenta_id</td><td>Identificador único de la cuenta</td></tr>
+                    <tr><td>cuenta_nombre</td><td>Nombre de la cuenta</td></tr>
+                    <tr><td>tipo_cuenta</td><td>Tipo de la cuenta</td></tr>
+                    <tr><td>banco</td><td>Entidad bancaria</td></tr>
+                    <tr><td>nro_mascarado</td><td>Número de cuenta enmascarado</td></tr>
+                    <tr><td>moneda_base</td><td>Moneda base de la cuenta</td></tr>
+                    <tr><td>activa</td><td>Indica si la cuenta está activa</td></tr>
+                </tbody>
+            </table>
+
+            <h3>Dimensión de Contrapartes</h3>
+            <table class="schema-table">
+                <thead>
+                    <tr><th>Columna</th><th>Descripción</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>contraparte_id</td><td>Identificador de la contraparte</td></tr>
+                    <tr><td>contraparte_nombre</td><td>Nombre de la contraparte</td></tr>
+                    <tr><td>tipo</td><td>Tipo general de contraparte</td></tr>
+                    <tr><td>subtipo</td><td>Subtipo de la contraparte</td></tr>
+                    <tr><td>activa</td><td>Indica si está activa</td></tr>
+                    <tr><td>notas</td><td>Notas adicionales</td></tr>
+                </tbody>
+            </table>
+
+            <h3>Dimensión de Categorías</h3>
+            <table class="schema-table">
+                <thead>
+                    <tr><th>Columna</th><th>Descripción</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>categoria_id</td><td>Identificador de la categoría</td></tr>
+                    <tr><td>tipo_flujo</td><td>Tipo de flujo (ingreso/gasto)</td></tr>
+                    <tr><td>categoria_nombre</td><td>Nombre de la categoría</td></tr>
+                    <tr><td>grupo</td><td>Grupo principal</td></tr>
+                    <tr><td>subgrupo</td><td>Subgrupo de la categoría</td></tr>
+                </tbody>
+            </table>
+
+            <h3>Dimensión de Instrumentos</h3>
+            <table class="schema-table">
+                <thead>
+                    <tr><th>Columna</th><th>Descripción</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>instrumento_id</td><td>Identificador del instrumento</td></tr>
+                    <tr><td>instrumento_nombre</td><td>Nombre del instrumento</td></tr>
+                    <tr><td>tipo</td><td>Tipo de instrumento</td></tr>
+                    <tr><td>emisor</td><td>Entidad emisora</td></tr>
+                    <tr><td>monto_inicial</td><td>Importe inicial</td></tr>
+                    <tr><td>plazo</td><td>Plazo en días</td></tr>
+                    <tr><td>tasa</td><td>Tasa de interés</td></tr>
+                    <tr><td>v_cuota</td><td>Valor de la cuota</td></tr>
+                    <tr><td>monto_actual</td><td>Saldo actual</td></tr>
+                    <tr><td>cupo</td><td>Cupo disponible</td></tr>
+                    <tr><td>moneda</td><td>Moneda del instrumento</td></tr>
+                    <tr><td>observaciones</td><td>Notas u observaciones</td></tr>
+                </tbody>
+            </table>
+        </section>
     </main>
 
     <!-- Footer -->

--- a/styles.css
+++ b/styles.css
@@ -1149,6 +1149,30 @@ a:focus-visible {
     font-weight: 600;
 }
 
+/* Schema tables */
+.dimensions-section {
+    margin-top: var(--spacing-8);
+}
+
+.schema-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: var(--spacing-6);
+}
+
+.schema-table th,
+.schema-table td {
+    border: 1px solid var(--border-light);
+    padding: var(--spacing-2) var(--spacing-3);
+    text-align: left;
+}
+
+.schema-table th {
+    background-color: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
 /* Print styles */
 @media print {
     .navbar,


### PR DESCRIPTION
## Summary
- Document database dimensions (cuentas, contrapartes, categorías, instrumentos) with column descriptions in the web page
- Add basic styling for schema tables

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b45f2338832c953b8c51433bb93c