### PR TITLE
Add dimension tables and UI for data management

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -12,3 +12,173 @@ CREATE TABLE IF NOT EXISTS movimientos (
   moneda TEXT,
   tasa_cambio REAL
 );
+
+-- Table for cuentas
+CREATE TABLE IF NOT EXISTS cuentas (
+  cuenta_id TEXT PRIMARY KEY,
+  cuenta_nombre TEXT,
+  tipo_cuenta TEXT,
+  banco TEXT,
+  nro_mascarado TEXT,
+  moneda_base TEXT,
+  activa TEXT
+);
+
+-- Initial data for cuentas
+INSERT INTO cuentas (cuenta_id, cuenta_nombre, tipo_cuenta, banco, nro_mascarado, moneda_base, activa) VALUES
+('CTA_001','Banco de Chile','Cuenta Corriente','Banco de Chile','', 'CLP','SI'),
+('CTA_002','Banco Estado','Cuenta RUT','Banco Estado','', 'CLP','SI'),
+('CTA_003','Banco Falabella','Cuenta Corriente','Banco Falabella','', 'CLP','SI'),
+('CTA_004','Banco Santander','Cuenta Corriente','Banco Santander','', 'CLP','SI'),
+('CTA_005','BCI','Cuenta Corriente','Banco de Créditos e Inversiones','', 'CLP','NO'),
+('CTA_006','Coopeuch','Cuenta Vista','Coopeuch','', 'CLP','SI'),
+('CTA_007','Fpay','Billetera digital','Banco Falabella','', 'CLP','NO'),
+('CTA_008','Chek','Billetera digital','Banco Ripley','', 'CLP','SI'),
+('CTA_009','Tenpo','Billetera digital','Fintech','', 'CLP','SI'),
+('CTA_010','Junaeb','Gubernamental','Edenred','', 'CLP','NO'),
+('CTA_011','Mercado Pago','Billetera digital','Mercadolibre','', 'CLP','SI'),
+('CTA_012','Cuota Coopeuch','Ahorro/Inversión','Coopeuch','', 'CLP','SI'),
+('CTA_013','Paypal','Billetera digital','Paypal','', 'USD','SI'),
+('CTA_014','Caja Efectivo','Efectivo','N/A','', 'CLP','SI'),
+('CTA_015','Prestamo por cobrar - Corto Plazo','Corto plazo','Cuenta de Cobro','', 'CLP','SI'),
+('CTA_016','Prestamo por cobrar - Largo Plazo','Largo plazo','Cuenta de Cobro','', 'CLP','SI');
+
+-- Table for contrapartes
+CREATE TABLE IF NOT EXISTS contrapartes (
+  contraparte_id TEXT PRIMARY KEY,
+  contraparte_nombre TEXT,
+  tipo TEXT,
+  subtipo TEXT,
+  activa TEXT,
+  notas TEXT
+);
+
+-- Initial data for contrapartes
+INSERT INTO contrapartes (contraparte_id, contraparte_nombre, tipo, subtipo, activa, notas) VALUES
+('CTR_001','Lorena Rojas','Personas','Deudor','',NULL),
+('CTR_002','Dagoberto Godoy','Personas','Deudor','',NULL),
+('CTR_003','Franco Godoy','Personas','Deudor','',NULL),
+('CTR_004','Michell Godoy','Personas','Deudor','',NULL),
+('CTR_005','Dayana Godoy','Personas','Deudor','',NULL),
+('CTR_006','Daphne Lever','Personas','Deudor','',NULL),
+('CTR_007','Camila Villaroel','Personas','Deudor','',NULL),
+('CTR_008','Deivi Ramos','Personas','Deudor','',NULL),
+('CTR_009','Francisca Llanos','Personas','Deudor','',NULL),
+('CTR_010','Lucas Martinez','Personas','Deudor','',NULL),
+('CTR_011','Marcos Godoy','Personas','Deudor','',NULL),
+('CTR_012','Maria Escobar','Personas','Deudor','',NULL),
+('CTR_013','Camilo Campos','Personas','Deudor','',NULL),
+('CTR_014','Nadim Asfari','Personas','Deudor','',NULL),
+('CTR_015','Rita Balmacena','Personas','Deudor','',NULL),
+('CTR_016','Sebastian Aravena','Personas','Deudor','',NULL),
+('CTR_017','Vanessa Rojas','Personas','Deudor','',NULL),
+('CTR_018','Javiera Cortés','Personas','Deudor','',NULL),
+('CTR_019','Laura Lucero','Personas','Deudor','',NULL),
+('CTR_020','Diego Godoy','Personas','Deudor','',NULL),
+('CTR_021','Susan Godoy','Personas','Deudor','',NULL),
+('CTR_022','María Ignacia Cavieres','Personas','Deudor','',NULL),
+('CTR_023','Acreedor Diego Godoy','Personas','Acreedor','',NULL),
+('CTR_024','Acreedor Lorena Rojas','Personas','Acreedor','',NULL),
+('CTR_025','Mini-Empresa','Empresa','Deudor','',NULL);
+
+-- Table for categorias
+CREATE TABLE IF NOT EXISTS categorias (
+  categoria_id TEXT PRIMARY KEY,
+  tipo_flujo TEXT,
+  categoria_nombre TEXT,
+  grupo TEXT,
+  subgrupo TEXT
+);
+
+-- Initial data for categorias
+INSERT INTO categorias (categoria_id, tipo_flujo, categoria_nombre, grupo, subgrupo) VALUES
+('CAT_001','Ajuste','Ajuste contable','Ajustes/Otros','-'),
+('CAT_002','Gasto','Otros gastos','Gastos variables','Otros'),
+('CAT_003','Gasto','Alimentación','Gastos variables','Comida y bebidas'),
+('CAT_004','Gasto','Donaciones y Regalos','Gastos variables','Regalos'),
+('CAT_005','Gasto','Hogar y Jardín','Gastos variables','Mantenimiento hogar'),
+('CAT_006','Gasto','Ropa y Aseo Personal','Gastos variables','Vestimenta'),
+('CAT_007','Gasto','Salud y Bienestar','Gastos variables','Salud eventual'),
+('CAT_008','Gasto','Transporte','Gastos variables','Transporte'),
+('CAT_009','Gasto','Mantenimiento Vehicular','Gastos variables','Auto y combustible'),
+('CAT_010','Gasto','Mascotas','Gastos variables','Mascotas'),
+('CAT_011','Gasto','Comunicación','Gastos fijos','Telefonía/Internet'),
+('CAT_012','Gasto','Educación y Formación','Gastos fijos','Educación'),
+('CAT_013','Gasto','Entretenimiento y Suscripciones','Gastos fijos','Entretenimiento'),
+('CAT_014','Gasto','Servicios Básicos','Gastos fijos','Agua, luz, gas'),
+('CAT_015','Gasto','Seguros','Gastos fijos','Seguros'),
+('CAT_016','Operación financiera','Pago préstamo','Operaciones financieras','Préstamos'),
+('CAT_017','Operación financiera','Recepción préstamo','Operaciones financieras','Préstamos'),
+('CAT_018','Operación financiera','Pago tarjeta de crédito','Operaciones financieras','Tarjetas'),
+('CAT_019','Operación financiera','Impuestos, Interés y Tarifas','Operaciones financieras','Obligaciones fiscales'),
+('CAT_020','Operación financiera','Comisiones Bancarias','Operaciones financieras','Comisiones'),
+('CAT_021','Mov. interno','Transferencia interna','Movimientos internos','Transferencias'),
+('CAT_022','Mov. interno','Ahorro/Inversión Propia','Movimientos internos','Ahorro propio'),
+('CAT_023','Ingreso','Bonos/Comisiones','Ingresos','Laborales'),
+('CAT_024','Ingreso','Salario','Ingresos','Laborales'),
+('CAT_025','Ingreso','Ingreso por Venta','Ingresos','Ventas'),
+('CAT_026','Ingreso','Ingreso por Inversiones','Ingresos','Inversiones'),
+('CAT_027','Ingreso','Ingresos Pasivos','Ingresos','Pasivos'),
+('CAT_028','Ingreso','Ingresos por Actividades Esporádicas','Ingresos','Eventuales'),
+('CAT_029','Ingreso','Ingresos por Beneficios Gubernamentales','Ingresos','Subsidios'),
+('CAT_030','Ingreso','Reembolsos','Ingresos','Reembolsos'),
+('CAT_031','Ingreso','Intereses Bancarios a Favor','Ingresos','Intereses'),
+('CAT_032','Operación financiera','Pago de deuda','Operaciones financieras','Préstamos'),
+('CAT_033','Patrimonio','Patrimonio','Ajustes/Otros','Ajuste');
+
+-- Table for instrumentos
+CREATE TABLE IF NOT EXISTS instrumentos (
+  instrumento_id TEXT PRIMARY KEY,
+  instrumento_nombre TEXT,
+  tipo TEXT,
+  emisor TEXT,
+  monto_inicial REAL,
+  plazo TEXT,
+  tasa REAL,
+  v_cuota REAL,
+  monto_actual REAL,
+  cupo REAL,
+  moneda TEXT,
+  observaciones TEXT
+);
+
+-- Initial data for instrumentos
+INSERT INTO instrumentos (instrumento_id, instrumento_nombre, tipo, emisor, monto_inicial, plazo, tasa, v_cuota, monto_actual, cupo, moneda, observaciones) VALUES
+('INS_001','CMR Falabella','Tarjeta de Crédito','CMR Falabella',NULL,NULL,NULL,NULL,NULL,1250000,'CLP',NULL),
+('INS_002','Banco de Chile Signature','Tarjeta de Crédito','Banco de Chile Signature',NULL,NULL,NULL,NULL,NULL,1000000,'CLP',NULL),
+('INS_003','Cencosud Scotiabank','Tarjeta de Crédito','Cencosud Scotiabank',NULL,NULL,NULL,NULL,NULL,1520000,'CLP',NULL),
+('INS_004','Banco de Chile Signature USD','Tarjeta de Crédito','Banco de Chile Signature USD',NULL,NULL,NULL,NULL,NULL,100,'USD',NULL),
+('INS_005','RappiCard','Tarjeta de Crédito','RappiCard',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_006','RappiCard USD','Tarjeta de Crédito','RappiCard USD',NULL,NULL,NULL,NULL,NULL,NULL,'USD',NULL),
+('INS_007','Santander Life','Tarjeta de Crédito','Santander Life',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_008','BCI Classic','Tarjeta de Crédito','BCI Classic',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_010','Fintual Acciones','Instrumentos de Inversión y Ahorro','Fintual Acciones',NULL,NULL,NULL,NULL,NULL,NULL,'USD',NULL),
+('INS_011','Creación de Empresa','Instrumentos de Inversión y Ahorro','Creación de Empresa',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_012','Fintual','Instrumentos de Inversión y Ahorro','Fintual',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_013','Ahorro vivienda Coopeuch','Instrumentos de Inversión y Ahorro','Ahorro vivienda Coopeuch',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_014','McAfee','Prestamo Otorgado','Cobros Mensuales',45290,12,7.94,5990,NULL,NULL,'CLP',NULL),
+('INS_015','Microsoft','Prestamo Otorgado','Cobros Mensuales',46390,15,12,6990,NULL,NULL,'CLP',NULL),
+('INS_016','Cobros Mensuales','Prestamo Otorgado','Alexis Godoy Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_017','Mini-Empresa','Prestamo Otorgado','Alexis Godoy Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_018','TV Alexis','Prestamo Otorgado','Alexis Godoy Rojas',479990,12,0,39999,NULL,NULL,'CLP','Compra de TV de Alexis pagado por Lorena Rojas'),
+('INS_019','Zapatillas Alexis','Prestamo Otorgado','Alexis Godoy Rojas',115280,4,0,28820,NULL,NULL,'CLP','Compra de zapatillas de Alexis pagado por Lorena Rojas'),
+('INS_020','Toallas','Prestamo Otorgado','Alexis Godoy Rojas',32186,3,3,11418,NULL,NULL,'CLP','Compra de toallas de Lorena Rojas'),
+('INS_021','Amortiguador','Prestamo Otorgado','Alexis Godoy Rojas',84990,6,0,14165,NULL,NULL,'CLP','Compra de amortiguadores de Auto pagado por Dagoberto Godoy'),
+('INS_022','Apple TV','Prestamo Otorgado','Alexis Godoy Rojas',155990,12,0,12999,NULL,NULL,'CLP','Compra de Apple TV pagado por Lorena Rojas'),
+('INS_023','Línea Blanca','Prestamo Otorgado','Alexis Godoy Rojas',40980,3,0,13660,NULL,NULL,'CLP','Compra de articulos de linea blanca a Lorena Rojas'),
+('INS_024','Spotify','Instrumentos de Inversión y Ahorro','Cobros Mensuales',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_025','Entradas','Prestamo Otorgado','Lorena Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_026','PC','Prestamo Otorgado','Lorena Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_027','Youtube Premium','Instrumentos de Inversión y Ahorro','Cobros Mensuales',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_028','Editor Video','Prestamo Otorgado','Lorena Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_029','Amazon','Instrumentos de Inversión y Ahorro','Cobros Mensuales',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_030','Comida','Prestamo Otorgado','Alexis Godoy Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_031','Depositos a Plazo','Instrumentos de Inversión y Ahorro','Banco Falabella',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_033','Regalo Padre','Prestamo Otorgado','Lorena Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_034','Impresora','Prestamo Otorgado','Lorena Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_035','Barra de Sonido','Prestamo Otorgado','Lorena Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_036','Aspiradora','Prestamo Otorgado','Lorena Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_037','Bebidas','Prestamo Otorgado','Mini-Empresa',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_038','Sodimac','Prestamo Otorgado','Lorena Rojas',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL),
+('INS_039','Bienestar','Prestamo Otorgado','Hospital',NULL,NULL,NULL,NULL,NULL,NULL,'CLP',NULL);
+

--- a/dimensions.html
+++ b/dimensions.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Administración de Dimensiones</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Administración de Dimensiones</h1>
+  <div id="app"></div>
+  <script src="dimensions.js"></script>
+</body>
+</html>

--- a/dimensions.js
+++ b/dimensions.js
@@ -1,0 +1,114 @@
+const entities = {
+  cuentas: {
+    label: 'Cuentas',
+    fields: ['cuenta_id','cuenta_nombre','tipo_cuenta','banco','nro_mascarado','moneda_base','activa']
+  },
+  contrapartes: {
+    label: 'Contrapartes',
+    fields: ['contraparte_id','contraparte_nombre','tipo','subtipo','activa','notas']
+  },
+  categorias: {
+    label: 'Categorías',
+    fields: ['categoria_id','tipo_flujo','categoria_nombre','grupo','subgrupo']
+  },
+  instrumentos: {
+    label: 'Instrumentos',
+    fields: ['instrumento_id','instrumento_nombre','tipo','emisor','monto_inicial','plazo','tasa','v_cuota','monto_actual','cupo','moneda','observaciones']
+  }
+};
+
+const app = document.getElementById('app');
+
+function createSection(entity, config) {
+  const section = document.createElement('section');
+  const title = document.createElement('h2');
+  title.textContent = config.label;
+  section.appendChild(title);
+
+  const table = document.createElement('table');
+  table.id = `${entity}-table`;
+  section.appendChild(table);
+
+  const form = document.createElement('form');
+  form.id = `${entity}-form`;
+  config.fields.forEach(f => {
+    const input = document.createElement('input');
+    input.name = f;
+    input.placeholder = f;
+    form.appendChild(input);
+  });
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.textContent = 'Agregar';
+  form.appendChild(submit);
+  section.appendChild(form);
+
+  app.appendChild(section);
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = {};
+    config.fields.forEach(f => {
+      data[f] = form[f].value;
+    });
+    fetch(`/${entity}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).then(() => {
+      form.reset();
+      loadData(entity, config);
+    });
+  });
+}
+
+function renderTable(entity, config, data) {
+  const table = document.getElementById(`${entity}-table`);
+  table.innerHTML = '';
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  config.fields.forEach(f => {
+    const th = document.createElement('th');
+    th.textContent = f;
+    headerRow.appendChild(th);
+  });
+  const actionTh = document.createElement('th');
+  actionTh.textContent = 'Acciones';
+  headerRow.appendChild(actionTh);
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  data.forEach(item => {
+    const row = document.createElement('tr');
+    config.fields.forEach(f => {
+      const td = document.createElement('td');
+      td.textContent = item[f] || '';
+      row.appendChild(td);
+    });
+    const actionTd = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.textContent = 'Eliminar';
+    btn.addEventListener('click', () => deleteItem(entity, item[config.fields[0]], config));
+    actionTd.appendChild(btn);
+    row.appendChild(actionTd);
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+}
+
+function loadData(entity, config) {
+  fetch(`/${entity}`)
+    .then(r => r.json())
+    .then(data => renderTable(entity, config, data));
+}
+
+function deleteItem(entity, id, config) {
+  fetch(`/${entity}/${id}`, { method: 'DELETE' })
+    .then(() => loadData(entity, config));
+}
+
+Object.entries(entities).forEach(([entity, config]) => {
+  createSection(entity, config);
+  loadData(entity, config);
+});

--- a/index.html
+++ b/index.html
@@ -118,6 +118,10 @@
                     <i class="fas fa-target"></i>
                     <span>Crear Objetivo</span>
                 </button>
+                <a class="action-btn secondary" id="manageDimensionsBtn" href="dimensions.html">
+                    <i class="fas fa-table"></i>
+                    <span>Dimensiones</span>
+                </a>
             </div>
         </section>
 

--- a/server.js
+++ b/server.js
@@ -16,6 +16,119 @@ app.get('/movimientos', (req, res) => {
   });
 });
 
+// ---- Endpoints for dimension tables ----
+
+// Generic helper to handle database operations
+function handleAll(table, res) {
+  db.all(`SELECT * FROM ${table}`, [], (err, rows) => {
+    if (err) {
+      res.status(500).json({ error: `Error fetching ${table}` });
+    } else {
+      res.json(rows);
+    }
+  });
+}
+
+// Cuentas
+app.get('/cuentas', (req, res) => handleAll('cuentas', res));
+
+app.post('/cuentas', (req, res) => {
+  const { cuenta_id, cuenta_nombre, tipo_cuenta, banco, nro_mascarado, moneda_base, activa } = req.body;
+  const stmt = `INSERT INTO cuentas (cuenta_id, cuenta_nombre, tipo_cuenta, banco, nro_mascarado, moneda_base, activa) VALUES (?, ?, ?, ?, ?, ?, ?)`;
+  db.run(stmt, [cuenta_id, cuenta_nombre, tipo_cuenta, banco, nro_mascarado, moneda_base, activa], function(err) {
+    if (err) {
+      res.status(500).json({ error: 'Error inserting cuenta' });
+    } else {
+      res.json({ cuenta_id, cuenta_nombre, tipo_cuenta, banco, nro_mascarado, moneda_base, activa });
+    }
+  });
+});
+
+app.delete('/cuentas/:id', (req, res) => {
+  db.run('DELETE FROM cuentas WHERE cuenta_id = ?', [req.params.id], function(err) {
+    if (err) {
+      res.status(500).json({ error: 'Error deleting cuenta' });
+    } else {
+      res.json({ deleted: this.changes });
+    }
+  });
+});
+
+// Contrapartes
+app.get('/contrapartes', (req, res) => handleAll('contrapartes', res));
+
+app.post('/contrapartes', (req, res) => {
+  const { contraparte_id, contraparte_nombre, tipo, subtipo, activa, notas } = req.body;
+  const stmt = `INSERT INTO contrapartes (contraparte_id, contraparte_nombre, tipo, subtipo, activa, notas) VALUES (?, ?, ?, ?, ?, ?)`;
+  db.run(stmt, [contraparte_id, contraparte_nombre, tipo, subtipo, activa, notas], function(err) {
+    if (err) {
+      res.status(500).json({ error: 'Error inserting contraparte' });
+    } else {
+      res.json({ contraparte_id, contraparte_nombre, tipo, subtipo, activa, notas });
+    }
+  });
+});
+
+app.delete('/contrapartes/:id', (req, res) => {
+  db.run('DELETE FROM contrapartes WHERE contraparte_id = ?', [req.params.id], function(err) {
+    if (err) {
+      res.status(500).json({ error: 'Error deleting contraparte' });
+    } else {
+      res.json({ deleted: this.changes });
+    }
+  });
+});
+
+// Categorias
+app.get('/categorias', (req, res) => handleAll('categorias', res));
+
+app.post('/categorias', (req, res) => {
+  const { categoria_id, tipo_flujo, categoria_nombre, grupo, subgrupo } = req.body;
+  const stmt = `INSERT INTO categorias (categoria_id, tipo_flujo, categoria_nombre, grupo, subgrupo) VALUES (?, ?, ?, ?, ?)`;
+  db.run(stmt, [categoria_id, tipo_flujo, categoria_nombre, grupo, subgrupo], function(err) {
+    if (err) {
+      res.status(500).json({ error: 'Error inserting categoria' });
+    } else {
+      res.json({ categoria_id, tipo_flujo, categoria_nombre, grupo, subgrupo });
+    }
+  });
+});
+
+app.delete('/categorias/:id', (req, res) => {
+  db.run('DELETE FROM categorias WHERE categoria_id = ?', [req.params.id], function(err) {
+    if (err) {
+      res.status(500).json({ error: 'Error deleting categoria' });
+    } else {
+      res.json({ deleted: this.changes });
+    }
+  });
+});
+
+// Instrumentos
+app.get('/instrumentos', (req, res) => handleAll('instrumentos', res));
+
+app.post('/instrumentos', (req, res) => {
+  const { instrumento_id, instrumento_nombre, tipo, emisor, monto_inicial, plazo, tasa, v_cuota, monto_actual, cupo, moneda, observaciones } = req.body;
+  const stmt = `INSERT INTO instrumentos (instrumento_id, instrumento_nombre, tipo, emisor, monto_inicial, plazo, tasa, v_cuota, monto_actual, cupo, moneda, observaciones) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+  db.run(stmt, [instrumento_id, instrumento_nombre, tipo, emisor, monto_inicial, plazo, tasa, v_cuota, monto_actual, cupo, moneda, observaciones], function(err) {
+    if (err) {
+      res.status(500).json({ error: 'Error inserting instrumento' });
+    } else {
+      res.json({ instrumento_id, instrumento_nombre, tipo, emisor, monto_inicial, plazo, tasa, v_cuota, monto_actual, cupo, moneda, observaciones });
+    }
+  });
+});
+
+app.delete('/instrumentos/:id', (req, res) => {
+  db.run('DELETE FROM instrumentos WHERE instrumento_id = ?', [req.params.id], function(err) {
+    if (err) {
+      res.status(500).json({ error: 'Error deleting instrumento' });
+    } else {
+      res.json({ deleted: this.changes });
+    }
+  });
+});
+
 app.post('/movimientos', (req, res) => {
   const {
     fecha,


### PR DESCRIPTION
## Summary
- add database tables for accounts, counterparties, categories and instruments with initial data
- expose CRUD API endpoints for new dimension tables
- create simple UI to view/add/remove dimension records and link from dashboard

## Testing
- `npm test`
- `node server.js` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba790914832c98167bf05f2dea92