### PR TITLE
Populate transaction form with dimension names

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,20 +382,12 @@
                         <label for="cuentaId">Cuenta</label>
                         <select id="cuentaId" required>
                             <option value="">Seleccionar cuenta</option>
-                            <option value="1">Cuenta 1</option>
-                            <option value="2">Cuenta 2</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="categoriaId">Categoría</label>
                         <select id="categoriaId" required>
                             <option value="">Seleccionar categoría</option>
-                            <option value="food">Alimentación</option>
-                            <option value="transport">Transporte</option>
-                            <option value="entertainment">Entretenimiento</option>
-                            <option value="utilities">Servicios</option>
-                            <option value="salary">Salario</option>
-                            <option value="other">Otros</option>
                         </select>
                     </div>
                     <div class="form-group">
@@ -414,17 +406,12 @@
                         <label for="contraparteId">Contraparte</label>
                         <select id="contraparteId">
                             <option value="">Seleccionar contraparte</option>
-                            <option value="cliente">Cliente</option>
-                            <option value="proveedor">Proveedor</option>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="instrumentoId">Instrumento</label>
                         <select id="instrumentoId">
                             <option value="">Seleccionar instrumento</option>
-                            <option value="efectivo">Efectivo</option>
-                            <option value="tarjeta">Tarjeta</option>
-                            <option value="transferencia">Transferencia</option>
                         </select>
                     </div>
                     <div class="form-group">

--- a/script.js
+++ b/script.js
@@ -524,10 +524,41 @@ class FinanceTracker {
         }, 500);
     }
 
-    openTransactionModal() {
+    async loadDimensionOptions() {
+        const mappings = [
+            { url: '/cuentas', selectId: 'cuentaId', idField: 'cuenta_id', textField: 'cuenta_nombre' },
+            { url: '/categorias', selectId: 'categoriaId', idField: 'categoria_id', textField: 'categoria_nombre' },
+            { url: '/instrumentos', selectId: 'instrumentoId', idField: 'instrumento_id', textField: 'instrumento_nombre' },
+            { url: '/contrapartes', selectId: 'contraparteId', idField: 'contraparte_id', textField: 'contraparte_nombre' }
+        ];
+
+        for (const map of mappings) {
+            try {
+                const res = await fetch(map.url);
+                const data = await res.json();
+                const select = document.getElementById(map.selectId);
+                if (select) {
+                    const placeholder = select.querySelector('option[value=""]');
+                    select.innerHTML = '';
+                    if (placeholder) select.appendChild(placeholder);
+                    data.forEach(item => {
+                        const opt = document.createElement('option');
+                        opt.value = item[map.idField];
+                        opt.textContent = item[map.textField];
+                        select.appendChild(opt);
+                    });
+                }
+            } catch (e) {
+                console.error('Error loading', map.url, e);
+            }
+        }
+    }
+
+    async openTransactionModal() {
         const modal = document.getElementById('transactionModal');
         modal?.classList.add('show');
         document.body.style.overflow = 'hidden';
+        await this.loadDimensionOptions();
     }
 
     closeTransactionModal() {
@@ -557,7 +588,7 @@ class FinanceTracker {
             categoria_id: categoria,
             descripcion,
             fecha,
-            contraparte_id: document.getElementById('contrapartesId').value,
+            contraparte_id: document.getElementById('contraparteId').value,
             instrumento_id: document.getElementById('instrumentoId').value,
             moneda: document.getElementById('moneda').value,
             tasa_cambio: parseFloat(document.getElementById('tasaCambio').value),


### PR DESCRIPTION
## Summary
- Populate new transaction modal selects with accounts, categories, instruments and counterparties from backend
- Load dimension options when opening modal and fix counterparty field id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c2de8d18832c97a4749f83d17c2b