### PR TITLE
Cargar cuentas de la base de datos en nuevas transacciones

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
                     </div>
                     <div class="form-group">
                         <label for="cuentaId">Cuenta</label>
-                        <select id="cuentaId" required>
+                        <select id="cuentaId">
                             <option value="">Seleccionar cuenta</option>
                         </select>
                     </div>

--- a/script.js
+++ b/script.js
@@ -49,6 +49,7 @@ class FinanceTracker {
             }
         };
         this.currentLanguage = 'es';
+        this.API_BASE = window.location.protocol === 'file:' ? 'http://localhost:3000' : '';
         this.loadTransactions().then(() => this.init());
     }
 
@@ -534,7 +535,7 @@ class FinanceTracker {
 
         for (const map of mappings) {
             try {
-                const res = await fetch(map.url);
+                const res = await fetch(`${this.API_BASE}${map.url}`);
                 const data = await res.json();
                 const select = document.getElementById(map.selectId);
                 if (select) {
@@ -584,7 +585,7 @@ class FinanceTracker {
         const transaction = {
             tipo,
             monto,
-            cuenta_id: document.getElementById('cuentaId').value,
+            cuenta_id: document.getElementById('cuentaId').value || null,
             categoria_id: categoria,
             descripcion,
             fecha,
@@ -622,11 +623,6 @@ class FinanceTracker {
 
         if (!transaction.monto || transaction.monto <= 0) {
             this.showFieldError('transactionAmount', 'Ingresa una cantidad válida');
-            isValid = false;
-        }
-
-        if (!transaction.cuenta_id) {
-            this.showFieldError('cuentaId', 'Selecciona una cuenta');
             isValid = false;
         }
 
@@ -730,7 +726,7 @@ class FinanceTracker {
 
     async loadTransactions() {
         try {
-            const res = await fetch('/movimientos');
+            const res = await fetch(`${this.API_BASE}/movimientos`);
             if (!res.ok) throw new Error('Network response was not ok');
             this.transactions = await res.json();
         } catch (error) {
@@ -741,7 +737,7 @@ class FinanceTracker {
 
     async saveTransaction(transaction) {
         try {
-            const res = await fetch('/movimientos', {
+            const res = await fetch(`${this.API_BASE}/movimientos`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(transaction)


### PR DESCRIPTION
## Summary
- Obtiene las cuentas desde la API y las muestra en el desplegable de nueva transacción.
- Ajusta el formulario para que la cuenta sea opcional y se guarde el `cuenta_id` correspondiente.
- Añade soporte para usar la API tanto desde archivo local como servidor.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c7b70390832c91b00ff1e37d2ad4