### PR TITLE
Invoke database initialization when run directly

### DIFF
--- a/scripts/init_db.js
+++ b/scripts/init_db.js
@@ -21,3 +21,7 @@ function init() {
 }
 
 module.exports = init;
+
+if (require.main === module) {
+  init();
+}


### PR DESCRIPTION
## Summary
- Call `init()` when `scripts/init_db.js` executed as a standalone script

## Testing
- `npm test`
- `npm run init-db`


------
https://chatgpt.com/codex/tasks/task_e_68a8db218794832c8df84a5dd3e90501